### PR TITLE
feat: Enhance SLURM worker configuration and environment setup

### DIFF
--- a/backend/sh/slurm_env.sh
+++ b/backend/sh/slurm_env.sh
@@ -4,14 +4,16 @@ export APP_DIR=         # e.g.: /data/apps/app.orch/dev
 export BASE_DIR=        # e.g.: ${APP_DIR}/orchestration
 export CONDA_PATH=      # e.g.: ${APP_DIR}/miniconda3/bin/activate
 export RABBITMQ_ENV=    # e.g.: /home/app.orch/rabbitmq/.env
+export WORKER_NAME="slurm"
 
 set -a
-. $RABBITMQ_ENV         # environment variables related to rabbitmq running on srvorch-dev server 
+. $RABBITMQ_ENV         # environment variables related to rabbitmq running on srvorch-dev server
 . $BASE_DIR/.env
 set +a
 
 echo "Activating environment"
 
+# shellcheck source=/data/apps/app.orch/dev/miniconda3/bin/activate
 source $CONDA_PATH || { echo "Failed to activate Conda environment"; exit 1; }
 
 if [ ! -d "$PIPELINES_DIR" ]; then
@@ -19,7 +21,7 @@ if [ ! -d "$PIPELINES_DIR" ]; then
     exit 1
 fi
 
-HASENV=`conda env list | grep 'orchestration '`
+HASENV=$(conda env list | grep 'orchestration ')
 
 if [ -z "$HASENV" ]; then
     echo "Create virtual environment..."

--- a/backend/sh/slurm_worker.sh
+++ b/backend/sh/slurm_worker.sh
@@ -8,13 +8,15 @@ host=$(hostname)
 
 sleep 5
 
-echo "Starting Celery SLURM Worker"
+slurmname="${WORKER_NAME}"
+
+echo "Starting Celery SLURM Worker: ${slurmname} on host ${host}"
 
 rm -rf /tmp/slurm-*.pid
 
-celery -A orchestration worker -Q slurm,slurm.${host} \
+celery -A orchestration worker -Q "${slurmname}","${slurmname}"."${host}" \
     -l "${LOGGING_LEVEL}" \
-    --pidfile="/tmp/slurm-%n.pid" \
-    --logfile="${LOG_DIR}/slurm.${host}.log" \
+    --pidfile="/tmp/${slurmname}-%n.pid" \
+    --logfile="${LOG_DIR}/${slurmname}.${host}.log" \
     --pool="solo"
 


### PR DESCRIPTION
This commit enhances the SLURM worker configuration and environment setup by:

- Introducing a `WORKER_NAME` variable in `slurm_env.sh` to allow for customized worker naming. The default value is "slurm".
- Modifying `slurm_worker.sh` to utilize the `WORKER_NAME` variable for queue names, PID file names, and log file names. This allows for running multiple SLURM workers with distinct configurations.
- Updating `slurm_worker.sh` to print the worker name and hostname for better logging and identification.
- Adding a shellcheck directive to `slurm_env.sh` to ignore the sourcing of the conda activate script.